### PR TITLE
fixes Warning: Did not expect server HTML to contain the text node in…

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,8 +7,6 @@
   </head>
   <body>
     <div>this is from index.html</div>
-    <div id="root">
-      <!--ROOT_TAG-->
-    </div>
+    <div id="root"><!--ROOT_TAG--></div>
   </body>
 </html>


### PR DESCRIPTION
Fixes `Warning: Did not expect server HTML to contain the text node in <div>` in console caused by the whitespace in server html response. react-dom.hydrate expects html sent by the server and client hydrated html to be identical and that's why it produced the warning.